### PR TITLE
Add support for custom events fired by clicking on notifications.

### DIFF
--- a/src/server/api/notification.ts
+++ b/src/server/api/notification.ts
@@ -4,14 +4,15 @@ import {notifyLaravel} from "../utils";
 const router = express.Router();
 
 router.post('/', (req, res) => {
-    const {title, body} = req.body
+    const {title, body, customEvent: event} = req.body
+    const eventName = customEvent ?? '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked';
 
     const notification = new Notification({title, body});
 
     notification.on("click", (event)=>{
         notifyLaravel('events', {
-            event: '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked',
-            payload: []
+            event: eventName,
+            payload: JSON.stringify(event)
         })
     })
 


### PR DESCRIPTION
https://nativephp.com/docs/1/the-basics/notifications#notification-click-events says that you can send custom events when clicking on a notification. However, this code currently always sends the same static event, and furthermore can be improved by sending the payload of the click event for better handling of the click event in PHP.

This code will also benefit from a related PR to nativephp/laravel.