### PR TITLE
Option to show/hide menu on Windows / Linux

### DIFF
--- a/src/server/api/window.ts
+++ b/src/server/api/window.ts
@@ -92,6 +92,7 @@ router.post('/open', (req, res) => {
         showDevTools,
         fullscreen,
         kiosk,
+        autoHideMenuBar,
     } = req.body
 
     if (state.windows[id]) {
@@ -135,7 +136,7 @@ router.post('/open', (req, res) => {
         titleBarStyle,
         vibrancy,
         focusable,
-        autoHideMenuBar: true,
+        autoHideMenuBar,
         ...(process.platform === 'linux' ? {icon: state.icon} : {}),
         webPreferences: {
             backgroundThrottling: false,


### PR DESCRIPTION
Complimentary adjustments to the same pull request on the Laravel repo. Enables showing and hiding the menu on Windows / Linux.