### PR TITLE
Fix PHP port resolver issue

### DIFF
--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -30,6 +30,7 @@ const appPath = getAppPath();
 function getPhpPort() {
     return __awaiter(this, void 0, void 0, function* () {
         return yield (0, get_port_1.default)({
+            host: '127.0.0.1',
             port: get_port_1.default.makeRange(8100, 9000)
         });
     });

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -17,6 +17,7 @@ const appPath = getAppPath();
 
 async function getPhpPort() {
     return await getPort({
+        host: '127.0.0.1',
         port: getPort.makeRange(8100, 9000)
     });
 }


### PR DESCRIPTION
This PR fixes an issue where no two NativePHP apps could run at the same time, because it would not properly detect the next available port.
Fixes https://github.com/NativePHP/laravel/issues/66