### PR TITLE
Add endpoint to update the context-menu

### DIFF
--- a/dist/server/api/menuBar.js
+++ b/dist/server/api/menuBar.js
@@ -15,6 +15,11 @@ router.post("/label", (req, res) => {
     const { label } = req.body;
     state_1.default.activeMenuBar.tray.setTitle(label);
 });
+router.post("/context-menu", (req, res) => {
+    res.sendStatus(200);
+    const { contextMenu } = req.body;
+    state_1.default.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
+});
 router.post("/show", (req, res) => {
     res.sendStatus(200);
     state_1.default.activeMenuBar.showWindow();

--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -16,6 +16,13 @@ router.post("/label", (req, res) => {
   state.activeMenuBar.tray.setTitle(label);
 });
 
+router.post("/context-menu", (req, res) => {
+  res.sendStatus(200);
+  const { contextMenu } = req.body;
+  
+  state_1.default.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
+});
+
 router.post("/show", (req, res) => {
   res.sendStatus(200);
 

--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -20,7 +20,7 @@ router.post("/context-menu", (req, res) => {
   res.sendStatus(200);
   const { contextMenu } = req.body;
   
-  state_1.default.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
+  state.activeMenuBar.tray.setContextMenu(buildMenu(contextMenu));
 });
 
 router.post("/show", (req, res) => {


### PR DESCRIPTION
# The Situation
I'm creating a menubar app, that uses the menu-bar items to display some info.
When that info gets updated, I need to edit the menubar, but the `/create` endpoint cannot be called again.

## Proposed solution
Therefor I've added an endpoint `/context-menu` to update the already set context-menu of the menubar.
