### PR TITLE
Add windowPosition to menuBar

### DIFF
--- a/dist/server/api/menuBar.js
+++ b/dist/server/api/menuBar.js
@@ -25,7 +25,7 @@ router.post("/hide", (req, res) => {
 });
 router.post("/create", (req, res) => {
     res.sendStatus(200);
-    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextWindow, contextMenu } = req.body;
+    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextWindow, windowPosition, contextMenu } = req.body;
     if (onlyShowContextWindow === true) {
         const tray = new electron_1.Tray(icon || state_1.default.icon.replace("icon.png", "IconTemplate.png"));
         tray.setContextMenu(buildMenu(contextMenu));
@@ -47,6 +47,7 @@ router.post("/create", (req, res) => {
             index: url,
             showDockIcon,
             showOnAllWorkspaces: false,
+            windowPosition: windowPosition !== null && windowPosition !== void 0 ? windowPosition : "trayCenter",
             browserWindow: {
                 width,
                 height,

--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -43,6 +43,7 @@ router.post("/create", (req, res) => {
     icon,
     showDockIcon,
     onlyShowContextWindow,
+    windowPosition,
     contextMenu
   } = req.body;
 
@@ -68,6 +69,7 @@ router.post("/create", (req, res) => {
       index: url,
       showDockIcon,
       showOnAllWorkspaces: false,
+      windowPosition: windowPosition ?? "trayCenter",
       browserWindow: {
         width,
         height,


### PR DESCRIPTION
Adds support for passing [positioner](https://github.com/jenslind/electron-positioner) 'position' strings such as `trayLeft` and `trayBottomCenter` to [menubar](https://github.com/maxogden/menubar) via the windowPosition key.

I will also send a PR for [NativePHP/laravel](https://github.com/NativePHP/laravel) that adds the ability to send the strings from the PHP side of things. 