### PR TITLE
Implement support for file dropping on menu bar icon

### DIFF
--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -104,9 +104,12 @@ router.post("/create", (req, res) => {
       });
     });
 
-    state.activeMenuBar.tray.on("drop-files", () => {
+    state.activeMenuBar.tray.on("drop-files", (event, files) => {
       notifyLaravel("events", {
-        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDroppedFiles"
+        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDroppedFiles",
+        payload: [
+          files
+        ]
       });
     });
 

--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -104,6 +104,12 @@ router.post("/create", (req, res) => {
       });
     });
 
+    state.activeMenuBar.tray.on("drop-files", () => {
+      notifyLaravel("events", {
+        event: "\\Native\\Laravel\\Events\\MenuBar\\MenuBarDroppedFiles"
+      });
+    });
+
     if (onlyShowContextWindow !== true) {
       state.activeMenuBar.tray.on("right-click", () => {
         notifyLaravel("events", {


### PR DESCRIPTION
This pull request implements a new event handler that triggers when a file is dropped on top of the menu bar icon (https://www.electronjs.org/docs/latest/api/tray#event-drop-files-macos).

Doing so will emit the `MenuBarDroppedFiles` Laravel event.