### PR TITLE
Add 'withoutIcon' option to create endpoint

### DIFF
--- a/dist/server/api/menuBar.js
+++ b/dist/server/api/menuBar.js
@@ -25,9 +25,10 @@ router.post("/hide", (req, res) => {
 });
 router.post("/create", (req, res) => {
     res.sendStatus(200);
-    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, showDockIcon, onlyShowContextWindow, contextMenu } = req.body;
+    const { width, height, url, label, alwaysOnTop, vibrancy, backgroundColor, transparency, icon, withoutIcon, showDockIcon, onlyShowContextWindow, contextMenu } = req.body;
+    const menuBarIcon = withoutIcon ? electron_1.nativeImage.createEmpty() : (icon || state_1.default.icon.replace("icon.png", "IconTemplate.png"));
     if (onlyShowContextWindow === true) {
-        const tray = new electron_1.Tray(icon || state_1.default.icon.replace("icon.png", "IconTemplate.png"));
+        const tray = new electron_1.Tray(menuBarIcon);
         tray.setContextMenu(buildMenu(contextMenu));
         state_1.default.activeMenuBar = (0, menubar_1.menubar)({
             tray,
@@ -43,7 +44,7 @@ router.post("/create", (req, res) => {
     }
     else {
         state_1.default.activeMenuBar = (0, menubar_1.menubar)({
-            icon: icon || state_1.default.icon.replace("icon.png", "IconTemplate.png"),
+            icon: menuBarIcon,
             index: url,
             showDockIcon,
             showOnAllWorkspaces: false,

--- a/src/server/api/menuBar.ts
+++ b/src/server/api/menuBar.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { Menu, Tray } from "electron";
+import { Menu, Tray, nativeImage } from "electron";
 import { mapMenu } from "./helper";
 import state from "../state";
 import { menubar } from "menubar";
@@ -41,13 +41,16 @@ router.post("/create", (req, res) => {
     backgroundColor,
     transparency,
     icon,
+    withoutIcon,
     showDockIcon,
     onlyShowContextWindow,
     contextMenu
   } = req.body;
 
+  const menuBarIcon = withoutIcon ? nativeImage.createEmpty() : (icon || state.icon.replace("icon.png", "IconTemplate.png"));
+
   if (onlyShowContextWindow === true) {
-    const tray = new Tray(icon || state.icon.replace("icon.png", "IconTemplate.png"));
+    const tray = new Tray(menuBarIcon);
     tray.setContextMenu(buildMenu(contextMenu));
 
     state.activeMenuBar = menubar({
@@ -64,7 +67,7 @@ router.post("/create", (req, res) => {
 
   } else {
     state.activeMenuBar = menubar({
-      icon: icon || state.icon.replace("icon.png", "IconTemplate.png"),
+      icon: menuBarIcon,
       index: url,
       showDockIcon,
       showOnAllWorkspaces: false,


### PR DESCRIPTION
# Situation
I want to create a text-only menubar application. Currently NativePHP cannot work with this. 

## Solution
Added a 'withoutIcon' option when creating the menubar, so that a text-only menubar application can be created, without an icon.