### PR TITLE
Run scheduler once while waiting for setInterval()

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -128,6 +128,8 @@ class NativePHP {
             let now = new Date();
             let delay = (60 - now.getSeconds()) * 1000 + (1000 - now.getMilliseconds());
             setTimeout(() => {
+                console.log("Running scheduler...");
+                (0, server_1.runScheduler)(apiPort.port, phpIniSettings);
                 schedulerInterval = setInterval(() => {
                     console.log("Running scheduler...");
                     (0, server_1.runScheduler)(apiPort.port, phpIniSettings);

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,8 @@ class NativePHP {
       let delay = (60 - now.getSeconds()) * 1000 + (1000 - now.getMilliseconds());
 
       setTimeout(() => {
+        console.log("Running scheduler...")
+        runScheduler(apiPort.port, phpIniSettings);
         schedulerInterval = setInterval(() => {
           console.log("Running scheduler...")
           runScheduler(apiPort.port, phpIniSettings);


### PR DESCRIPTION
Work was recently done (https://github.com/NativePHP/laravel/issues/72) to add support for sub-minute scheduling (yay) by executing a `setTimeout()` to start on the :00s of every minute.  This is great, but has the unintended side-effect that if the server is started at :01 of a minute, the `setTimeout` isn't called for another 59 seconds, at which point it waits for another 60 seconds before the `setInterval` is called to start the scheduler.  That means on first run, we may be waiting for nearly 2 minutes before the scheduler actually kicks off.

This PR just adds a single manual call of the scheduler which will run at the first :00 to tide us over until the `setInterval` calls take over.