### PR TITLE
Allow specifying of PHP app port of `artisan serve` via configuration file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -117,9 +117,10 @@ class NativePHP {
                     electron_1.app.setAsDefaultProtocolClient(deepLinkProtocol);
                 }
             }
+            state_1.default.phpPort = nativePHPConfig === null || nativePHPConfig === void 0 ? void 0 : nativePHPConfig.app_port;
             const apiPort = yield (0, server_1.startAPI)();
             console.log('API server started on port', apiPort.port);
-            phpProcesses = yield (0, server_1.servePhpApp)(apiPort.port, phpIniSettings);
+            phpProcesses = yield (0, server_1.servePhpApp)(apiPort.port, phpIniSettings, nativePHPConfig === null || nativePHPConfig === void 0 ? void 0 : nativePHPConfig.app_port);
             websocketProcess = (0, server_1.serveWebsockets)();
             yield (0, utils_2.notifyLaravel)('booted');
             if (((_a = nativePHPConfig === null || nativePHPConfig === void 0 ? void 0 : nativePHPConfig.updater) === null || _a === void 0 ? void 0 : _a.enabled) === true) {

--- a/dist/server/index.js
+++ b/dist/server/index.js
@@ -21,10 +21,10 @@ Object.defineProperty(exports, "retrieveNativePHPConfig", { enumerable: true, ge
 Object.defineProperty(exports, "retrievePhpIniSettings", { enumerable: true, get: function () { return php_1.retrievePhpIniSettings; } });
 const utils_1 = require("./utils");
 const state_1 = __importDefault(require("./state"));
-function servePhpApp(apiPort, phpIniSettings) {
+function servePhpApp(apiPort, phpIniSettings, appPort = null) {
     return __awaiter(this, void 0, void 0, function* () {
         const processes = [];
-        const result = yield (0, php_1.serveApp)(state_1.default.randomSecret, apiPort, phpIniSettings);
+        const result = yield (0, php_1.serveApp)(state_1.default.randomSecret, apiPort, phpIniSettings, appPort);
         processes.push(result.process);
         processes.push((0, php_1.startQueueWorker)(state_1.default.randomSecret, apiPort, phpIniSettings));
         state_1.default.phpPort = result.port;

--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -27,11 +27,11 @@ const databasePath = (0, path_1.join)(electron_1.app.getPath('userData'), 'datab
 const databaseFile = (0, path_1.join)(databasePath, 'database.sqlite');
 const argumentEnv = getArgumentEnv();
 const appPath = getAppPath();
-function getPhpPort() {
+function getPhpPort(appPort = null) {
     return __awaiter(this, void 0, void 0, function* () {
         return yield (0, get_port_1.default)({
             host: '127.0.0.1',
-            port: get_port_1.default.makeRange(8100, 9000)
+            port: appPort || get_port_1.default.makeRange(8100, 9000)
         });
     });
 }
@@ -164,7 +164,7 @@ function getDefaultEnvironmentVariables(secret, apiPort) {
         NATIVEPHP_RECENT_PATH: getPath('recent'),
     };
 }
-function serveApp(secret, apiPort, phpIniSettings) {
+function serveApp(secret, apiPort, phpIniSettings, appPort) {
     return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
         const appPath = getAppPath();
         console.log('Starting PHP server...', `${state_1.default.php} artisan serve`, appPath, phpIniSettings);
@@ -186,7 +186,7 @@ function serveApp(secret, apiPort, phpIniSettings) {
             console.log('Skipping Database migration while in development.');
             console.log('You may migrate manually by running: php artisan native:migrate');
         }
-        const phpPort = yield getPhpPort();
+        const phpPort = yield getPhpPort(appPort);
         const serverPath = (0, path_1.join)(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
         const phpServer = callPhp(['-S', `127.0.0.1:${phpPort}`, serverPath], {
             cwd: (0, path_1.join)(appPath, 'public'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,11 +129,13 @@ class NativePHP {
         }
       }
 
+      state.phpPort = nativePHPConfig?.app_port
+      
       // Start PHP server and websockets
       const apiPort = await startAPI()
       console.log('API server started on port', apiPort.port);
 
-      phpProcesses = await servePhpApp(apiPort.port, phpIniSettings)
+      phpProcesses = await servePhpApp(apiPort.port, phpIniSettings, nativePHPConfig?.app_port)
 
       websocketProcess = serveWebsockets()
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,9 +11,9 @@ import {
 import { appendCookie } from "./utils";
 import state from "./state";
 
-export async function servePhpApp(apiPort: number, phpIniSettings: object) {
+export async function servePhpApp(apiPort: number, phpIniSettings: object, appPort: number | null = null) {
   const processes = [];
-  const result = await serveApp(state.randomSecret, apiPort, phpIniSettings);
+  const result = await serveApp(state.randomSecret, apiPort, phpIniSettings, appPort);
   processes.push(result.process);
 
   processes.push(startQueueWorker(state.randomSecret, apiPort, phpIniSettings));
@@ -35,7 +35,7 @@ export function startQueue(apiPort: number, phpIniSettings: object) {
 }
 
 export function startAPI(): Promise<APIProcess> {
-  return startAPIServer(state.randomSecret);
+  return startAPIServer(state.randomSecret); 
 }
 
 export { serveWebsockets, retrieveNativePHPConfig, retrievePhpIniSettings };

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -15,10 +15,10 @@ const databaseFile = join(databasePath, 'database.sqlite')
 const argumentEnv = getArgumentEnv();
 const appPath = getAppPath();
 
-async function getPhpPort() {
+async function getPhpPort(appPort: number | null = null) {
     return await getPort({
         host: '127.0.0.1',
-        port: getPort.makeRange(8100, 9000)
+        port: appPort || getPort.makeRange(8100, 9000)
     });
 }
 
@@ -180,7 +180,7 @@ function getDefaultEnvironmentVariables(secret, apiPort) {
   };
 }
 
-function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
+function serveApp(secret, apiPort, phpIniSettings, appPort): Promise<ProcessResult> {
     return new Promise(async (resolve, reject) => {
         const appPath = getAppPath();
 
@@ -215,7 +215,7 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
             console.log('You may migrate manually by running: php artisan native:migrate')
         }
 
-        const phpPort = await getPhpPort();
+        const phpPort = await getPhpPort(appPort);
 
         const serverPath = join(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php')
         const phpServer = callPhp(['-S', `127.0.0.1:${phpPort}`, serverPath], {


### PR DESCRIPTION
This PR introduces a minor yet impactful enhancement to the servePhpApp function, offering better flexibility in configuration.

The servePhpApp function now includes an optional appPort parameter. This is especially useful for users who wish to specify a different port for their application without altering the underlying logic.

Laravel users can now set the port using the `nativephp.app_port` configuration variable in `config/nativephp.php`. For those who don't specify the configuration variable, the function retains its previous behavior.