### PR TITLE
Implement desktop notification options

### DIFF
--- a/dist/server/api/notification.js
+++ b/dist/server/api/notification.js
@@ -8,8 +8,8 @@ const electron_1 = require("electron");
 const utils_1 = require("../utils");
 const router = express_1.default.Router();
 router.post('/', (req, res) => {
-    const { title, body } = req.body;
-    const notification = new electron_1.Notification({ title, body });
+    const { title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml } = req.body;
+    const notification = new electron_1.Notification({ title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml });
     notification.on("click", (event) => {
         (0, utils_1.notifyLaravel)('events', {
             event: '\\Native\\Laravel\\Events\\Notifications\\NotificationClicked',

--- a/src/server/api/notification.ts
+++ b/src/server/api/notification.ts
@@ -4,9 +4,9 @@ import {notifyLaravel} from "../utils";
 const router = express.Router();
 
 router.post('/', (req, res) => {
-    const {title, body} = req.body
+    const {title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml} = req.body
 
-    const notification = new Notification({title, body});
+    const notification = new Notification({title, body, subtitle, silent, icon, hasReply, timeoutType, replyPlaceholder, sound, urgency, actions, closeButtonText, toastXml});
 
     notification.on("click", (event)=>{
         notifyLaravel('events', {


### PR DESCRIPTION
This PR add some options like subtitle, silent and so on  for [Electron Notification API](https://www.electronjs.org/docs/latest/api/notification#new-notificationoptions).

If this PR get merged, I will add some public method like `subtitle($subtitle)` to `Native\Laravel\Notification` class, and create a PR to  [`NativePHP/laravel`](https://github.com/nativephp/laravel) 