### PR TITLE
Add fullscreenable

### DIFF
--- a/src/server/api/window.ts
+++ b/src/server/api/window.ts
@@ -108,6 +108,7 @@ router.post('/open', (req, res) => {
         transparency,
         showDevTools,
         fullscreen,
+        fullscreenable,
         kiosk,
         autoHideMenuBar,
     } = req.body
@@ -166,6 +167,7 @@ router.post('/open', (req, res) => {
             nodeIntegration: true,
         },
         fullscreen,
+        fullscreenable,
         kiosk,
     })
 


### PR DESCRIPTION
Allows windows to be marked as [`fullscreenable`](https://www.electronjs.org/docs/latest/api/browser-window#winfullscreenable) which is what allows the maximize/fullscreen traffic light to be enabled on macOS.

Fixes https://github.com/NativePHP/laravel/issues/339 (partially)