### PR TITLE
Battery/AC power, plus more

### DIFF
--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -20,6 +20,7 @@ import contextMenuRoutes from "./api/contextMenu";
 import settingsRoutes from "./api/settings";
 import shellRoutes from "./api/shell";
 import progressBarRoutes from "./api/progressBar";
+import powerMonitorRoutes from "./api/powerMonitor";
 import { Server } from "net";
 
 export interface APIProcess {
@@ -52,6 +53,7 @@ async function startAPIServer(randomSecret: string): Promise<APIProcess> {
     httpServer.use("/api/context", contextMenuRoutes);
     httpServer.use("/api/menu-bar", menuBarRoutes);
     httpServer.use("/api/progress-bar", progressBarRoutes);
+    httpServer.use("/api/power-monitor", powerMonitorRoutes);
 
     if (process.env.NODE_ENV === "development") {
       httpServer.use("/api/debug", debugRoutes);

--- a/src/server/api/powerMonitor.ts
+++ b/src/server/api/powerMonitor.ts
@@ -9,7 +9,7 @@ router.get('/get-system-idle-state', (req, res) => {
     })
 });
 
-router.post('/get-system-idle-time', (req, res) => {
+router.get('/get-system-idle-time', (req, res) => {
     res.json({
         result: powerMonitor.getSystemIdleTime(),
     })

--- a/src/server/api/powerMonitor.ts
+++ b/src/server/api/powerMonitor.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import { powerMonitor } from 'electron'
+import { notifyLaravel } from '../utils';
 const router = express.Router();
 
 router.get('/get-system-idle-state', (req, res) => {
@@ -25,5 +26,41 @@ router.get('/is-on-battery-power', (req, res) => {
         result: powerMonitor.isOnBatteryPower(),
     })
 });
+
+powerMonitor.addListener('on-ac', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\PowerStateChanged`,
+        payload: {
+            state: 'on-ac'
+        }
+    });
+})
+
+powerMonitor.addListener('on-battery', () => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\PowerStateChanged`,
+        payload: {
+            state: 'on-battery'
+        }
+    });
+})
+
+powerMonitor.addListener('thermal-state-change', (state: string) => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\ThermalStateChanged`,
+        payload: {
+            state
+        }
+    });
+})
+
+powerMonitor.addListener('speed-limit-change', (limit: number) => {
+    notifyLaravel("events", {
+        event: `\\Native\\Laravel\\Events\\PowerMonitor\\SpeedLimitChanged`,
+        payload: {
+            limit
+        }
+    });
+})
 
 export default router;

--- a/src/server/api/powerMonitor.ts
+++ b/src/server/api/powerMonitor.ts
@@ -1,0 +1,29 @@
+import express from 'express'
+import { powerMonitor } from 'electron'
+const router = express.Router();
+
+router.get('/get-system-idle-state', (req, res) => {
+    res.json({
+        result: powerMonitor.getSystemIdleState(req.body.threshold),
+    })
+});
+
+router.post('/get-system-idle-time', (req, res) => {
+    res.json({
+        result: powerMonitor.getSystemIdleTime(),
+    })
+});
+
+router.get('/get-current-thermal-state', (req, res) => {
+    res.json({
+        result: powerMonitor.getCurrentThermalState(),
+    })
+});
+
+router.get('/is-on-battery-power', (req, res) => {
+    res.json({
+        result: powerMonitor.isOnBatteryPower(),
+    })
+});
+
+export default router;


### PR DESCRIPTION
Hey! Thanks for all your hard work on NativePHP.

This PR adds the ability to determine the power state of the current device (on battery or connected to AC), as well as some other data we can get from Electron's `powerMonitor`.

This could come in really useful for apps that run long running jobs, or computationally expensive actions.

Here's a video of it in action: my app is hooking into the `PowerStateChanged` event to show a notification.

https://github.com/user-attachments/assets/b45db34c-7d64-4218-b685-b784cfb0e2aa

As well as an event for power state changes, it also implements:

- An event for when the thermal state changes (ie, when the fans are blaring)
- An event for when the CPU is being clocked (ie power saving mode)
- A getter for the current thermal state
- A getter to determine the idle state
- A getter to determine how long the device has been idle for
- A getter for whether we're on battery power or not

I've got another PR for the NativePHP/Laravel repo to complete this functionality, and I'll add a PR for the docs if you're happy with this change.

There are a few more things in the [powerMonitor](https://www.electronjs.org/docs/latest/api/power-monitor) that I can implement too if you're interested.

