### PR TITLE
Run obfuscated builds

### DIFF
--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -195,12 +195,12 @@ function serveApp(secret, apiPort, phpIniSettings) {
         if (!runningSecureBuild()) {
             callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings);
         }
-        if (store.get('migrated_version') !== electron_1.app.getVersion() && process.env.NODE_ENV !== 'development') {
+        if (store.get('migrated_version') !== electron_1.app.getVersion() && (process.env.NODE_ENV !== 'development' || runningSecureBuild())) {
             console.log('Migrating database...');
             callPhp(['artisan', 'migrate', '--force'], phpOptions, phpIniSettings);
             store.set('migrated_version', electron_1.app.getVersion());
         }
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV === 'development' && !runningSecureBuild()) {
             console.log('Skipping Database migration while in development.');
             console.log('You may migrate manually by running: php artisan native:migrate');
         }

--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -126,7 +126,6 @@ function ensureAppFoldersAreAvailable() {
 function startQueueWorker(secret, apiPort, phpIniSettings = {}) {
     const env = {
         APP_ENV: process.env.NODE_ENV === 'development' ? 'local' : 'production',
-        APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
         NATIVEPHP_STORAGE_PATH: storagePath,
         NATIVEPHP_DATABASE_PATH: databaseFile,
         NATIVEPHP_API_URL: `http://localhost:${apiPort}/api/`,
@@ -160,7 +159,6 @@ function getPath(name) {
 function getDefaultEnvironmentVariables(secret, apiPort) {
     return {
         APP_ENV: process.env.NODE_ENV === 'development' ? 'local' : 'production',
-        APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
         LARAVEL_STORAGE_PATH: storagePath,
         NATIVEPHP_STORAGE_PATH: storagePath,
         NATIVEPHP_DATABASE_PATH: databaseFile,

--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -187,7 +187,11 @@ function serveApp(secret, apiPort, phpIniSettings) {
             console.log('You may migrate manually by running: php artisan native:migrate');
         }
         const phpPort = yield getPhpPort();
-        const serverPath = (0, path_1.join)(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
+        let serverPath = (0, path_1.join)(appPath, 'build', '__nativephp_app_bundle');
+        if (process.env.NODE_ENV !== 'production' || !(0, fs_1.existsSync)(serverPath)) {
+            console.log('* * * Building with source * * *');
+            serverPath = (0, path_1.join)(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
+        }
         const phpServer = callPhp(['-S', `127.0.0.1:${phpPort}`, serverPath], {
             cwd: (0, path_1.join)(appPath, 'public'),
             env

--- a/dist/server/php.js
+++ b/dist/server/php.js
@@ -46,7 +46,11 @@ function retrievePhpIniSettings() {
             cwd: appPath,
             env
         };
-        return yield (0, util_1.promisify)(child_process_1.execFile)(state_1.default.php, ['artisan', 'native:php-ini'], phpOptions);
+        let command = ['artisan', 'native:php-ini'];
+        if (runningSecureBuild()) {
+            command.unshift((0, path_1.join)(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        return yield (0, util_1.promisify)(child_process_1.execFile)(state_1.default.php, command, phpOptions);
     });
 }
 exports.retrievePhpIniSettings = retrievePhpIniSettings;
@@ -61,7 +65,11 @@ function retrieveNativePHPConfig() {
             cwd: appPath,
             env
         };
-        return yield (0, util_1.promisify)(child_process_1.execFile)(state_1.default.php, ['artisan', 'native:config'], phpOptions);
+        let command = ['artisan', 'native:config'];
+        if (runningSecureBuild()) {
+            command.unshift((0, path_1.join)(appPath, 'build', '__nativephp_app_bundle'));
+        }
+        return yield (0, util_1.promisify)(child_process_1.execFile)(state_1.default.php, command, phpOptions);
     });
 }
 exports.retrieveNativePHPConfig = retrieveNativePHPConfig;

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -65,6 +65,10 @@ function callPhp(args, options, phpIniSettings = {}) {
       args.unshift('-d', `${key}=${iniSettings[key]}`);
     });
 
+    if (parseInt(process.env.SHELL_VERBOSITY) > 0) {
+        console.log('Calling PHP', state.php, args)
+    }
+
     return spawn(
         state.php,
         args,
@@ -180,6 +184,10 @@ function getDefaultEnvironmentVariables(secret, apiPort) {
   };
 }
 
+function runningSecureBuild() {
+
+}
+
 function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
     return new Promise(async (resolve, reject) => {
         const appPath = getAppPath();
@@ -201,7 +209,7 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
 
         // Make sure the storage path is linked - as people can move the app around, we
         // need to run this every time the app starts
-        callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
+        // callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
 
         // Migrate the database
         if (store.get('migrated_version') !== app.getVersion() && process.env.NODE_ENV !== 'development') {
@@ -219,10 +227,10 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
 
         let serverPath = join(appPath, 'build', '__nativephp_app_bundle');
 
-        if (process.env.NODE_ENV !== 'production' || ! existsSync(serverPath)) {
-            console.log('* * * Building with source * * *');
-            serverPath = join(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
-        }
+        // if (process.env.NODE_ENV !== 'production' || ! existsSync(serverPath)) {
+        //     console.log('* * * Running from source * * *');
+        //     serverPath = join(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
+        // }
 
         const phpServer = callPhp(['-S', `127.0.0.1:${phpPort}`, serverPath], {
             cwd: join(appPath, 'public'),

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -231,13 +231,13 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
         }
 
         // Migrate the database
-        if (store.get('migrated_version') !== app.getVersion() && process.env.NODE_ENV !== 'development') {
+        if (store.get('migrated_version') !== app.getVersion() && (process.env.NODE_ENV !== 'development' || runningSecureBuild())) {
             console.log('Migrating database...')
             callPhp(['artisan', 'migrate', '--force'], phpOptions, phpIniSettings)
             store.set('migrated_version', app.getVersion())
         }
 
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV === 'development' && ! runningSecureBuild()) {
             console.log('Skipping Database migration while in development.')
             console.log('You may migrate manually by running: php artisan native:migrate')
         }

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -142,7 +142,7 @@ function ensureAppFoldersAreAvailable() {
 function startQueueWorker(secret, apiPort, phpIniSettings = {}) {
     const env = {
         APP_ENV: process.env.NODE_ENV === 'development' ? 'local' : 'production',
-        APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
+        // APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
         NATIVEPHP_STORAGE_PATH: storagePath,
         NATIVEPHP_DATABASE_PATH: databaseFile,
         NATIVEPHP_API_URL: `http://localhost:${apiPort}/api/`,
@@ -181,7 +181,7 @@ function getPath(name: string) {
 function getDefaultEnvironmentVariables(secret, apiPort) {
   return {
     APP_ENV: process.env.NODE_ENV === 'development' ? 'local' : 'production',
-    APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
+    // APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
     LARAVEL_STORAGE_PATH: storagePath,
     NATIVEPHP_STORAGE_PATH: storagePath,
     NATIVEPHP_DATABASE_PATH: databaseFile,

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -217,7 +217,13 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
 
         const phpPort = await getPhpPort();
 
-        const serverPath = join(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php')
+        let serverPath = join(appPath, 'build', '__nativephp_app_bundle');
+
+        if (process.env.NODE_ENV !== 'production' || ! existsSync(serverPath)) {
+            console.log('* * * Building with source * * *');
+            serverPath = join(appPath, 'vendor', 'laravel', 'framework', 'src', 'Illuminate', 'Foundation', 'resources', 'server.php');
+        }
+
         const phpServer = callPhp(['-S', `127.0.0.1:${phpPort}`, serverPath], {
             cwd: join(appPath, 'public'),
             env

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -23,18 +23,24 @@ async function getPhpPort() {
 }
 
 async function retrievePhpIniSettings() {
-  const env = {
-    NATIVEPHP_RUNNING: 'true',
-    NATIVEPHP_STORAGE_PATH: storagePath,
-    NATIVEPHP_DATABASE_PATH: databaseFile,
-  };
+    const env = {
+        NATIVEPHP_RUNNING: 'true',
+        NATIVEPHP_STORAGE_PATH: storagePath,
+        NATIVEPHP_DATABASE_PATH: databaseFile,
+    };
 
-  const phpOptions = {
-    cwd: appPath,
-    env
-  };
+    const phpOptions = {
+        cwd: appPath,
+        env
+    };
 
-  return await promisify(execFile)(state.php, ['artisan', 'native:php-ini'], phpOptions);
+    let command = ['artisan', 'native:php-ini'];
+
+    if (runningSecureBuild()) {
+        command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+    }
+
+    return await promisify(execFile)(state.php, command, phpOptions);
 }
 
 async function retrieveNativePHPConfig() {
@@ -49,7 +55,13 @@ async function retrieveNativePHPConfig() {
         env
     };
 
-    return await promisify(execFile)(state.php, ['artisan', 'native:config'], phpOptions);
+    let command = ['artisan', 'native:config'];
+
+    if (runningSecureBuild()) {
+        command.unshift(join(appPath, 'build', '__nativephp_app_bundle'));
+    }
+
+    return await promisify(execFile)(state.php, command, phpOptions);
 }
 
 function callPhp(args, options, phpIniSettings = {}) {

--- a/src/server/php.ts
+++ b/src/server/php.ts
@@ -166,6 +166,7 @@ function getDefaultEnvironmentVariables(secret, apiPort) {
   return {
     APP_ENV: process.env.NODE_ENV === 'development' ? 'local' : 'production',
     APP_DEBUG: process.env.NODE_ENV === 'development' ? 'true' : 'false',
+    LARAVEL_STORAGE_PATH: storagePath,
     NATIVEPHP_STORAGE_PATH: storagePath,
     NATIVEPHP_DATABASE_PATH: databaseFile,
     NATIVEPHP_API_URL: `http://localhost:${apiPort}/api/`,
@@ -209,7 +210,9 @@ function serveApp(secret, apiPort, phpIniSettings): Promise<ProcessResult> {
 
         // Make sure the storage path is linked - as people can move the app around, we
         // need to run this every time the app starts
-        // callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
+        // if (! runningSecureBuild()) {
+        //     callPhp(['artisan', 'storage:link', '--force'], phpOptions, phpIniSettings)
+        // }
 
         // Migrate the database
         if (store.get('migrated_version') !== app.getVersion() && process.env.NODE_ENV !== 'development') {


### PR DESCRIPTION
This adds the ability to run obfuscated NativePHP apps.

Obfuscated apps behave differently because the entire app is bundled into a single file. So various paths need to be mapped differently in order for the app to operate.

### Known issues:
- [ ] Production builds don't work
- [ ] `APP_DEBUG` must be set to `false`
- [ ] Running from source is currently disabled to make debugging this easier